### PR TITLE
Add express-statsd statsdKey support

### DIFF
--- a/http-router.js
+++ b/http-router.js
@@ -123,12 +123,13 @@ function routerExport(fn){
 
         // Add an express-statsd key that looks like http.post.api.hello.world for a HTTP POST to /api/hello/world URL
         // See https://github.com/uber/express-statsd
+        var env = process.env.NODE_ENV || 'production';
         var method = req.method || 'unknown_method';
         method = method.toLowerCase();
         var urlName = req.url || 'unknown_url';
         var path = parse(urlName).pathname.toLowerCase();
         path = path.replace(/\//g, ' ').trim().replace(/\s/g, '.');
-        req.statsdKey = ['http', method, path].join('.');
+        req.statsdKey = [env, 'http', method, path].join('.');
 
         // Param preconditions
         (function param(err) {


### PR DESCRIPTION
Added to each request a key named statsdKey which will create the correct key path for express-statsd. The key has the format http.get.api.hello.world for a HTTP GET request to /api/hello/world/
