### PR TITLE
Fixes for #42 & #43

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 node_modules
 docpad
 doc
-test
 web/*
 example/*

--- a/test/configure-server.js
+++ b/test/configure-server.js
@@ -48,6 +48,18 @@ exports.init = function(done){
         done(null,{d0:args.d0+'f0'})
       })
 
+      this.add('role:api,cmd:x1',function(args,done){
+        done(null,{x: args.x})
+      })
+
+      this.add('role:api,cmd:x2',function(args,done){
+        if (args.data && args.data.x){
+          return done(null,{x: args.data.x, loc: 1})
+        }
+        done(null,{x: args.x, loc: 0})
+
+      })
+
       this.add('role:api,cmd:c2',function(args,done){
         var src = 'PUT' == args.req$.method ? args.data : args
         done(null,{d1:src.d1+'f1',d2:src.d2})
@@ -95,6 +107,13 @@ exports.init = function(done){
           next()
         },
         map: {
+          x1: {
+            POST: true
+          },
+          x2: {
+            data: true,
+            POST: true
+          },
           c0: {
             alias: '/a0/:a0',
             GET:   true,

--- a/test/configure-server.js
+++ b/test/configure-server.js
@@ -21,7 +21,7 @@ exports.init = function (done) {
     app.use(Bodyparser.json())
 
     seneca.use(function p0 () {
-      this.add('role:api,cmd:c0', function (args, done) {
+      this.add('role:api,cmd:c0', function (args, response) {
         var out = {
           r0: 'r0' + args.a0,
           r1: 'r1' + args.a1,
@@ -39,38 +39,38 @@ exports.init = function (done) {
           out.c = args.c
         }
 
-        done(null, out)
+        response(null, out)
       })
 
-      this.add('role:api,cmd:c1', function (args, done) {
-        done(null, {d0: args.d0 + 'f0'})
+      this.add('role:api,cmd:c1', function (args, response) {
+        response(null, {d0: args.d0 + 'f0'})
       })
 
-      this.add('role:api,cmd:x1', function (args, done) {
-        done(null, {x: args.x})
+      this.add('role:api,cmd:x1', function (args, response) {
+        response(null, {x: args.x})
       })
 
-      this.add('role:api,cmd:x2', function (args, done) {
+      this.add('role:api,cmd:x2', function (args, response) {
         if (args.data && args.data.x) {
-          return done(null, {x: args.data.x, loc: 1})
+          return response(null, {x: args.data.x, loc: 1})
         }
-        done(null, {x: args.x, loc: 0})
+        response(null, {x: args.x, loc: 0})
       })
-      this.add('role:api,cmd:c2', function (args, done) {
+      this.add('role:api,cmd:c2', function (args, response) {
         var src = 'PUT' === args.req$.method ? args.data : args
-        done(null, {d1: src.d1 + 'f1', d2: src.d2})
+        response(null, {d1: src.d1 + 'f1', d2: src.d2})
       })
 
-      this.add('role:api,cmd:e0', function (args, done) {
-        done(new Error('e0'))
+      this.add('role:api,cmd:e0', function (args, response) {
+        response(new Error('e0'))
       })
 
-      this.add('role:api,cmd:e1', function (args, done) {
-        done(new Error('e1'))
+      this.add('role:api,cmd:e1', function (args, response) {
+        response(new Error('e1'))
       })
 
-      this.add('role:api,cmd:r0', function (args, done) {
-        done(null, {
+      this.add('role:api,cmd:r0', function (args, response) {
+        response(null, {
           ok: false,
           why: 'No input will satisfy me.',
           http$: {
@@ -114,22 +114,22 @@ exports.init = function (done) {
             c0: {
               alias: '/a0/:a0',
               GET: true,
-              POST: function (req, res, args, act, respond) {
+              POST: function (req, res, args, act, response) {
                 args.a0 = 'p' + args.a0
                 act(args, function (err, out) {
-                  if (err) return respond(err)
+                  if (err) return response(err)
 
                   out.r1 = 'p' + out.r1
                   out.c = args.c || undefined
-                  respond(null, out)
+                  response(null, out)
                 })
               },
               PUT: {
                 useparams: false,
                 usequery: false,
-                handler: function (req, res, args, act, respond) {
+                handler: function (req, res, args, act, response) {
                   args.a1 = 'p' + args.a1
-                  act(args, respond)
+                  act(args, response)
                 },
                 modify: function (result) {
                   result.out.o0 = 'p0'

--- a/test/configure-server.js
+++ b/test/configure-server.js
@@ -1,196 +1,194 @@
-"use strict";
+'use strict'
 
-var assert = require('assert')
+var Assert = require('assert')
 
-var agent
-var request = require('supertest')
-var cookieparser = require('cookie-parser')
-var bodyparser   = require('body-parser')
+var Request = require('supertest')
+var Cookieparser = require('cookie-parser')
+var Bodyparser = require('body-parser')
 
-exports.init = function(done){
-
+exports.init = function (done) {
   var seneca = require('seneca')({
-    default_plugins: { web: false },
+    default_plugins: {web: false},
     log: 'silent'
   })
   seneca.use('../web.js')
 
-  seneca.ready(function(err){
-    assert( !err, 'Seneca configured' )
+  seneca.ready(function (err) {
+    Assert(!err, 'Seneca configured')
 
     var app = require('express')()
-    app.use( cookieparser() )
-    app.use( bodyparser.json() )
+    app.use(Cookieparser())
+    app.use(Bodyparser.json())
 
-    seneca.use( function p0() {
-      this.add('role:api,cmd:c0',function(args,done){
+    seneca.use(function p0 () {
+      this.add('role:api,cmd:c0', function (args, done) {
         var out = {
-          r0:'r0'+args.a0,
-          r1:'r1'+args.a1,
-          r2:'r2'+args.a2,
-          x0:'r'+args.req$.x0,
+          r0: 'r0' + args.a0,
+          r1: 'r1' + args.a1,
+          r2: 'r2' + args.a2,
+          x0: 'r' + args.req$.x0,
           bad$: 'should-not-appear-in-response',
-          http$:{
-            headers:{
-              h0:'i0'
+          http$: {
+            headers: {
+              h0: 'i0'
             }
           }
         }
 
-        if(args.c) {
+        if (args.c) {
           out.c = args.c
         }
 
-        done(null,out)
+        done(null, out)
       })
 
-      this.add('role:api,cmd:c1',function(args,done){
-        done(null,{d0:args.d0+'f0'})
+      this.add('role:api,cmd:c1', function (args, done) {
+        done(null, {d0: args.d0 + 'f0'})
       })
 
-      this.add('role:api,cmd:x1',function(args,done){
-        done(null,{x: args.x})
+      this.add('role:api,cmd:x1', function (args, done) {
+        done(null, {x: args.x})
       })
 
-      this.add('role:api,cmd:x2',function(args,done){
-        if (args.data && args.data.x){
-          return done(null,{x: args.data.x, loc: 1})
+      this.add('role:api,cmd:x2', function (args, done) {
+        if (args.data && args.data.x) {
+          return done(null, {x: args.data.x, loc: 1})
         }
-        done(null,{x: args.x, loc: 0})
-
+        done(null, {x: args.x, loc: 0})
+      })
+      this.add('role:api,cmd:c2', function (args, done) {
+        var src = 'PUT' === args.req$.method ? args.data : args
+        done(null, {d1: src.d1 + 'f1', d2: src.d2})
       })
 
-      this.add('role:api,cmd:c2',function(args,done){
-        var src = 'PUT' == args.req$.method ? args.data : args
-        done(null,{d1:src.d1+'f1',d2:src.d2})
-      })
-
-      this.add('role:api,cmd:e0',function(args,done){
+      this.add('role:api,cmd:e0', function (args, done) {
         done(new Error('e0'))
       })
 
-      this.add('role:api,cmd:e1',function(args,done){
+      this.add('role:api,cmd:e1', function (args, done) {
         done(new Error('e1'))
       })
 
-      this.add('role:api,cmd:r0',function(args,done){
-        done(null,{
-          ok:false,
-          why:'No input will satisfy me.',
-          http$:{
-            status:400
+      this.add('role:api,cmd:r0', function (args, done) {
+        done(null, {
+          ok: false,
+          why: 'No input will satisfy me.',
+          http$: {
+            status: 400
           }
         })
       })
 
-      this.act('role:web',{use:{
-        prefix:'/t0',
-        pin:'role:api,cmd:*',
-        startware: function(req,res,next){
-          req.x0 = 'y0'
+      this.act('role:web', {
+        use: {
+          prefix: '/t0',
+          pin: 'role:api,cmd:*',
+          startware: function (req, res, next) {
+            req.x0 = 'y0'
 
-          if( req.body && 'a' == req.body.a ) {
-            req.body.a = 'A'
-          }
+            if (req.body && 'a' === req.body.a) {
+              req.body.a = 'A'
+            }
 
-          if( req.body && 'b' == req.body.b ) {
-            req.body.b = 'B'
-          }
+            if (req.body && 'b' === req.body.b) {
+              req.body.b = 'B'
+            }
 
-          next()
-        },
-        premap: function(args,req,res,next){
-          if( args.c ) {
-            args.c = 'C'
-          }
-
-          next()
-        },
-        map: {
-          x1: {
-            POST: true
+            next()
           },
-          x2: {
-            data: true,
-            POST: true
-          },
-          c0: {
-            alias: '/a0/:a0',
-            GET:   true,
-            POST:  function( req, res, args, act, respond ) {
-              args.a0 = 'p'+args.a0
-              act( args, function(err,out){
-                if( err ) return respond(err);
+          premap: function (args, req, res, next) {
+            if (args.c) {
+              args.c = 'C'
+            }
 
-                out.r1 = 'p'+out.r1
-                out.c = args.c || undefined
-                respond(null,out)
-              })
+            next()
+          },
+          map: {
+            x1: {
+              POST: true
             },
-            PUT: {
-              useparams: false,
-              usequery: false,
-              handler: function( req, res, args, act, respond ) {
-                args.a1 = 'p'+args.a1
-                act( args, respond )
+            x2: {
+              data: true,
+              POST: true
+            },
+            c0: {
+              alias: '/a0/:a0',
+              GET: true,
+              POST: function (req, res, args, act, respond) {
+                args.a0 = 'p' + args.a0
+                act(args, function (err, out) {
+                  if (err) return respond(err)
+
+                  out.r1 = 'p' + out.r1
+                  out.c = args.c || undefined
+                  respond(null, out)
+                })
               },
-              modify: function( result ) {
-                result.out.o0 = 'p0'
-                delete result.out.bad$
-              },
-              responder: function( req, res, err, obj ) {
-                obj.q0 = 'u0'
-                res.end( JSON.stringify(obj) )
+              PUT: {
+                useparams: false,
+                usequery: false,
+                handler: function (req, res, args, act, respond) {
+                  args.a1 = 'p' + args.a1
+                  act(args, respond)
+                },
+                modify: function (result) {
+                  result.out.o0 = 'p0'
+                  delete result.out.bad$
+                },
+                responder: function (req, res, err, obj) {
+                  obj.q0 = 'u0'
+                  res.end(JSON.stringify(obj))
+                }
               }
-            }
-          },
+            },
 
-          // GET will be used as default method
-          c1: {
-            data: true
-          },
+            // GET will be used as default method
+            c1: {
+              data: true
+            },
 
-          // GET not defined!!
-          c2: {
-            data: true,
-            PUT: true,
-            POST: { data: false }
-          },
+            // GET not defined!!
+            c2: {
+              data: true,
+              PUT: true,
+              POST: {data: false}
+            },
 
-          e0: true,
-          e1: {
-            responder: function( req, res, err, obj ) {
-              if( err ) {
-                // plain text for errors, no JSON
-                res.writeHead(500)
+            e0: true,
+            e1: {
+              responder: function (req, res, err, obj) {
+                if (err) {
+                  // plain text for errors, no JSON
+                  res.writeHead(500)
 
-                // seneca formatted Error object
-                res.end( err.details.message )
+                  // seneca formatted Error object
+                  res.end(err.details.message)
+                }
+                else res.send(obj)
               }
-              else res.send(obj)
-            }
-          },
+            },
 
-          r0: true
+            r0: true
+          }
         }
-      }})
+      })
     })
 
-    app.get( '/a', function(req,res){
+    app.get('/a', function (req, res) {
       res.send('A')
     })
-    app.post( '/a', function(req,res){
-      res.send( {a:req.body.a,c:req.body.c||undefined} )
+    app.post('/a', function (req, res) {
+      res.send({a: req.body.a, c: req.body.c || undefined})
     })
-    app.use( seneca.export('web') )
-    app.get( '/b', function(req,res){
+    app.use(seneca.export('web'))
+    app.get('/b', function (req, res) {
       res.send('B')
     })
-    app.post( '/b', function(req,res){
-      res.send( {b:req.body.b,c:req.body.c||undefined} )
+    app.post('/b', function (req, res) {
+      res.send({b: req.body.b, c: req.body.c || undefined})
     })
 
-    agent = request( app )
-    done(null, agent, seneca)
+    var Agent = Request(app)
+    done(null, Agent, seneca)
   })
 }

--- a/test/example.test.js
+++ b/test/example.test.js
@@ -1,47 +1,50 @@
-var assert = require('assert')
+var Assert = require('assert')
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
-var suite = lab.suite;
-var test = lab.test;
-var before = lab.before;
+var suite = lab.suite
+var test = lab.test
+var before = lab.before
 
 var agent
 var seneca
 
-var util = require('./util.js')
+var Util = require('./util.js')
 
 suite('example suite tests ', function () {
   before({}, function (done) {
-    util.init(function (err, agentData, si) {
+    Util.init(function (err, agentData, si) {
+      Assert(!err)
       agent = agentData
       seneca = si
 
-      seneca.add('role:foo,cmd:zig',function (args,done) {
-        done(null,{bar:'zig'})
+      seneca.add('role:foo,cmd:zig', function (args, done) {
+        done(null, {bar: 'zig'})
       })
 
-      seneca.add('role:foo,cmd:bar',function (args,done) {
-        done(null,{bar:'b'})
+      seneca.add('role:foo,cmd:bar', function (args, done) {
+        done(null, {bar: 'b'})
       })
 
-      var qaz = function (args,done) {
-        done(null,{qaz:args.zoo+'z'})
+      var qaz = function (args, done) {
+        done(null, {qaz: args.zoo + 'z'})
       }
 
-      seneca.add('role:foo,cmd:qaz',qaz)
-      seneca.add('role:foo,cmd:qazz',qaz)
+      seneca.add('role:foo,cmd:qaz', qaz)
+      seneca.add('role:foo,cmd:qazz', qaz)
 
 
-      seneca.act('role:web',{use:{
-        prefix:'/my-api',
-        pin:{role:'foo',cmd:'*'},
-        map:{
-          zig: true,
-          bar: {GET:true},
-          qaz: {GET:true, POST:true},
-          qazz: {GET:true, alias: '/qazz/:zoo'}
+      seneca.act('role:web', {
+        use: {
+          prefix: '/my-api',
+          pin: {role: 'foo', cmd: '*'},
+          map: {
+            zig: true,
+            bar: {GET: true},
+            qaz: {GET: true, POST: true},
+            qazz: {GET: true, alias: '/qazz/:zoo'}
+          }
         }
-      }}, done)
+      }, done)
     })
   })
 
@@ -50,8 +53,8 @@ suite('example suite tests ', function () {
       .get('/my-api/bar')
       .expect(200)
       .end(function (err, res) {
-        util.log(res)
-        assert.equal('b', res.body.bar, 'Invalid response')
+        Util.log(res)
+        Assert.equal('b', res.body.bar, 'Invalid response')
         done(err)
       })
   })
@@ -62,8 +65,8 @@ suite('example suite tests ', function () {
       .send({zoo: 'test'})
       .expect(200)
       .end(function (err, res) {
-        util.log(res)
-        assert.equal('testz', res.body.qaz, 'Invalid response')
+        Util.log(res)
+        Assert.equal('testz', res.body.qaz, 'Invalid response')
         done(err)
       })
   })
@@ -74,8 +77,8 @@ suite('example suite tests ', function () {
       .send({zoo: 'test'})
       .expect(200)
       .end(function (err, res) {
-        util.log(res)
-        assert.equal('testz', res.body.qaz, 'Invalid response')
+        Util.log(res)
+        Assert.equal('testz', res.body.qaz, 'Invalid response')
         done(err)
       })
   })
@@ -85,8 +88,8 @@ suite('example suite tests ', function () {
       .get('/my-api/qazz/val')
       .expect(200)
       .end(function (err, res) {
-        util.log(res)
-        assert.equal('valz', res.body.qaz, 'Invalid response')
+        Util.log(res)
+        Assert.equal('valz', res.body.qaz, 'Invalid response')
         done(err)
       })
   })

--- a/test/hapi.configure.server.js
+++ b/test/hapi.configure.server.js
@@ -39,13 +39,13 @@ exports.init = function ( done ) {
         }
 
         function c1(msg, done){
-          var out = _.extend(
-            {
-              t: 'c1'
-            },
-            msg.req$.params,
-            msg.req$.query
-          )
+          var out = {
+            t: 'c1',
+            m: msg.m,
+            x0: msg.x0,
+            a1: msg.a1,
+            a2: msg.a2
+          }
 
           done ( null, out )
         }

--- a/test/hapi.configure.server.js
+++ b/test/hapi.configure.server.js
@@ -1,13 +1,11 @@
-"use strict";
+'use strict'
 
-var assert = require ( 'assert' )
-
-var Chairo = require ( 'chairo' )
-const Hapi = require ( 'hapi' )
+var Chairo = require('chairo')
+const Hapi = require('hapi')
 var _ = require('lodash')
 
-exports.init = function ( done ) {
-  var server = new Hapi.Server ()
+exports.init = function (done) {
+  var server = new Hapi.Server()
   server.connection()
   var seneca
 
@@ -16,17 +14,17 @@ exports.init = function ( done ) {
       register: Chairo,
       options: {
         log: 'print',
-        web: require ( '..' )
+        web: require('..')
       }
-    }, function ( err ) {
-      console.log( 'Server registered Chairo', err )
+    }, function (err) {
+      console.log('Server registered Chairo', err)
       seneca = server.seneca
 
-      server.start( function () {
-        console.log( 'Server started' )
-        console.log( 'Server running at:', server.info.uri );
+      server.start(function () {
+        console.log('Server started')
+        console.log('Server running at:', server.info.uri)
 
-        function c0(msg, done){
+        function c0 (msg, done) {
           var out = _.extend(
             {
               t: 'c0'
@@ -35,10 +33,10 @@ exports.init = function ( done ) {
             msg.req$.query
           )
 
-          done ( null, out )
+          done(null, out)
         }
 
-        function c1(msg, done){
+        function c1 (msg, done) {
           var out = {
             t: 'c1',
             m: msg.m,
@@ -47,10 +45,10 @@ exports.init = function ( done ) {
             a2: msg.a2
           }
 
-          done ( null, out )
+          done(null, out)
         }
 
-        function c2(msg, done){
+        function c2 (msg, done) {
           var out = _.extend(
             {
               t: 'c2'
@@ -60,65 +58,63 @@ exports.init = function ( done ) {
             msg.req$.payload
           )
 
-          done ( null, out )
+          done(null, out)
         }
 
-        function e1(msg, done){
-          done ( new Error('some error') )
+        function e1 (msg, done) {
+          done(new Error('some error'))
         }
 
-        function x1(args,done){
-          done(null,{x: args.x})
+        function x1 (args, done) {
+          done(null, {x: args.x})
         }
 
-        function x2(args,done){
-          if (args.data && args.data.x){
-            return done(null,{x: args.data.x, loc: 1})
+        function x2 (args, done) {
+          if (args.data && args.data.x) {
+            return done(null, {x: args.data.x, loc: 1})
           }
-          done(null,{x: args.x, loc: 0})
+          done(null, {x: args.x, loc: 0})
         }
 
         seneca
-          .add( 'role:api,cmd:c0', c0 )
-          .add( 'role:api,cmd:c1', c1 )
-          .add( 'role:api,cmd:c2', c2 )
-          .add( 'role:api,cmd:e1', e1 )
-          .add( 'role:api,cmd:x1', x1 )
-          .add( 'role:api,cmd:x2', x2 )
+          .add('role:api,cmd:c0', c0)
+          .add('role:api,cmd:c1', c1)
+          .add('role:api,cmd:c2', c2)
+          .add('role:api,cmd:e1', e1)
+          .add('role:api,cmd:x1', x1)
+          .add('role:api,cmd:x2', x2)
 
-        seneca.act( 'role:web', {
+        seneca.act('role:web', {
           use: {
-            startware: function ( req, next ) {
+            startware: function (req, next) {
               req.params.x0 = 'y0'
 
-              next ()
+              next()
             },
             prefix: '/t0',
             pin: 'role:api,cmd:*',
             map: {
-              c0: { GET: true, alias: '/a0' },
-              c1: { GET: true, POST: true, alias: '/a0/:m' },
-              c2: { POST: true, alias: '/c0/:m' },
-              e1: { GET: true, alias: '/e1' },
-              x1: { POST: true },
-              x2: { POST: true, data: true }
+              c0: {GET: true, alias: '/a0'},
+              c1: {GET: true, POST: true, alias: '/a0/:m'},
+              c2: {POST: true, alias: '/c0/:m'},
+              e1: {GET: true, alias: '/e1'},
+              x1: {POST: true},
+              x2: {POST: true, data: true}
             }
           }
         }, function () {
-
-          seneca.act( 'role:web', {
+          seneca.act('role:web', {
             use: {
               prefix: '/r0',
               pin: 'role:api,cmd:*',
               map: {
-                c0: { GET: true, alias: '/x0' }
+                c0: {GET: true, alias: '/x0'}
               }
             }
           }, function () {
-            done ( null, server )
-          } )
-
-        } )
-      } )
-    } )
+            done(null, server)
+          })
+        })
+      })
+    })
 }

--- a/test/hapi.configure.server.js
+++ b/test/hapi.configure.server.js
@@ -15,6 +15,7 @@ exports.init = function ( done ) {
     {
       register: Chairo,
       options: {
+        log: 'print',
         web: require ( '..' )
       }
     }, function ( err ) {
@@ -66,10 +67,24 @@ exports.init = function ( done ) {
           done ( new Error('some error') )
         }
 
-        seneca.add( 'role:api,cmd:c0', c0 )
-        seneca.add( 'role:api,cmd:c1', c1 )
-        seneca.add( 'role:api,cmd:c2', c2 )
-        seneca.add( 'role:api,cmd:e1', e1 )
+        function x1(args,done){
+          done(null,{x: args.x})
+        }
+
+        function x2(args,done){
+          if (args.data && args.data.x){
+            return done(null,{x: args.data.x, loc: 1})
+          }
+          done(null,{x: args.x, loc: 0})
+        }
+
+        seneca
+          .add( 'role:api,cmd:c0', c0 )
+          .add( 'role:api,cmd:c1', c1 )
+          .add( 'role:api,cmd:c2', c2 )
+          .add( 'role:api,cmd:e1', e1 )
+          .add( 'role:api,cmd:x1', x1 )
+          .add( 'role:api,cmd:x2', x2 )
 
         seneca.act( 'role:web', {
           use: {
@@ -84,7 +99,9 @@ exports.init = function ( done ) {
               c0: { GET: true, alias: '/a0' },
               c1: { GET: true, POST: true, alias: '/a0/{m}' },
               c2: { POST: true, alias: '/c0/{m}' },
-              e1: { GET: true, alias: '/e1' }
+              e1: { GET: true, alias: '/e1' },
+              x1: { POST: true },
+              x2: { POST: true, data: true }
             }
           }
         }, function () {

--- a/test/hapi.configure.server.js
+++ b/test/hapi.configure.server.js
@@ -97,8 +97,8 @@ exports.init = function ( done ) {
             pin: 'role:api,cmd:*',
             map: {
               c0: { GET: true, alias: '/a0' },
-              c1: { GET: true, POST: true, alias: '/a0/{m}' },
-              c2: { POST: true, alias: '/c0/{m}' },
+              c1: { GET: true, POST: true, alias: '/a0/:m' },
+              c2: { POST: true, alias: '/c0/:m' },
               e1: { GET: true, alias: '/e1' },
               x1: { POST: true },
               x2: { POST: true, data: true }

--- a/test/hapi.stat.test.js
+++ b/test/hapi.stat.test.js
@@ -1,39 +1,40 @@
-"use strict";
+'use strict'
 
-var assert = require('assert')
+var Assert = require('assert')
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
-var suite = lab.suite;
-var test = lab.test;
-var before = lab.before;
+var suite = lab.suite
+var test = lab.test
+var before = lab.before
 
 var server
 
-suite('test server stats', function() {
-  before({}, function(done){
-    require('./hapi.configure.server.js').init(function(err, srv){
+suite('test server stats', function () {
+  before({}, function (done) {
+    require('./hapi.configure.server.js').init(function (err, srv) {
+      Assert(!err)
       server = srv
       done()
     })
   })
 
-  test('list services', function(done) {
-    server.seneca.act('role: web, list: service', function(err, services){
-      assert.ok(!err)
-      assert.equal(3, services.length)
-      assert.equal('role:api,cmd:*', services[1]['pin$'])
-      assert.equal(7, services[1]['routes$'].length)
+  test('list services', function (done) {
+    server.seneca.act('role: web, list: service', function (err, services) {
+      Assert.ok(!err)
+      Assert.equal(3, services.length)
+      Assert.equal('role:api,cmd:*', services[1]['pin$'])
+      Assert.equal(7, services[1]['routes$'].length)
 
       done()
     })
   })
 
-  test('list routes', function(done) {
-    server.seneca.act('role: web, list: route', function(err, routes){
-      assert.ok(!err)
+  test('list routes', function (done) {
+    server.seneca.act('role: web, list: route', function (err, routes) {
+      Assert.ok(!err)
 
-      assert.equal(8, routes.length)
-      assert.equal('/r0/x0', routes[0]['url'])
+      Assert.equal(8, routes.length)
+      Assert.equal('/r0/x0', routes[0]['url'])
 
       done()
     })

--- a/test/hapi.stat.test.js
+++ b/test/hapi.stat.test.js
@@ -22,7 +22,7 @@ suite('test server stats', function() {
       assert.ok(!err)
       assert.equal(3, services.length)
       assert.equal('role:api,cmd:*', services[1]['pin$'])
-      assert.equal(5, services[1]['routes$'].length)
+      assert.equal(7, services[1]['routes$'].length)
 
       done()
     })
@@ -32,7 +32,7 @@ suite('test server stats', function() {
     server.seneca.act('role: web, list: route', function(err, routes){
       assert.ok(!err)
 
-      assert.equal(6, routes.length)
+      assert.equal(8, routes.length)
       assert.equal('/r0/x0', routes[0]['url'])
 
       done()

--- a/test/hapi.url.test.js
+++ b/test/hapi.url.test.js
@@ -1,204 +1,205 @@
-"use strict";
+'use strict'
 
-var assert = require('assert')
+var Assert = require('assert')
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
-var suite = lab.suite;
-var test = lab.test;
-var before = lab.before;
+var suite = lab.suite
+var test = lab.test
+var before = lab.before
 
 var server
 
-suite('test server suite', function() {
-  before({}, function(done){
-    require('./hapi.configure.server.js').init(function(err, srv){
+suite('test server suite', function () {
+  before({}, function (done) {
+    require('./hapi.configure.server.js').init(function (err, srv) {
+      Assert(!err)
       server = srv
       done()
     })
   })
 
-  test('simple test 1', function(done) {
+  test('simple test 1', function (done) {
     var url = '/t0/a0'
 
-    server.inject(url, function(res){
-      assert.equal(200, res.statusCode)
-      assert.equal('c0', JSON.parse(res.payload).t)
-      assert.equal('y0', JSON.parse(res.payload).x0)
+    server.inject(url, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal('c0', JSON.parse(res.payload).t)
+      Assert.equal('y0', JSON.parse(res.payload).x0)
 
       done()
     })
   })
 
-  test('simple test 2', function(done) {
+  test('simple test 2', function (done) {
     var url = '/t0/a0/111'
 
-    server.inject(url, function(res){
-      assert.equal(200, res.statusCode)
-      assert.equal('111', JSON.parse(res.payload).m)
-      assert.equal('y0', JSON.parse(res.payload).x0)
-      assert.equal('c1', JSON.parse(res.payload).t)
+    server.inject(url, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal('111', JSON.parse(res.payload).m)
+      Assert.equal('y0', JSON.parse(res.payload).x0)
+      Assert.equal('c1', JSON.parse(res.payload).t)
 
       done()
     })
   })
 
-  test('simple test 3', function(done) {
+  test('simple test 3', function (done) {
     var url = '/t0/a0/222?a1=b1&a2=b2'
 
-    server.inject(url, function(res){
-      assert.equal(200, res.statusCode)
-      assert.equal('222', JSON.parse(res.payload).m)
-      assert.equal('y0', JSON.parse(res.payload).x0)
-      assert.equal('b1', JSON.parse(res.payload).a1)
-      assert.equal('b2', JSON.parse(res.payload).a2)
-      assert.equal('c1', JSON.parse(res.payload).t)
+    server.inject(url, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal('222', JSON.parse(res.payload).m)
+      Assert.equal('y0', JSON.parse(res.payload).x0)
+      Assert.equal('b1', JSON.parse(res.payload).a1)
+      Assert.equal('b2', JSON.parse(res.payload).a2)
+      Assert.equal('c1', JSON.parse(res.payload).t)
 
       done()
     })
   })
 
-  test('simple test post', function(done) {
+  test('simple test post', function (done) {
     var url = '/t0/a0/3333'
 
     server.inject({
       url: url,
       method: 'POST'
-    }, function(res){
-      assert.equal(200, res.statusCode)
-      assert.equal('3333', JSON.parse(res.payload).m)
-      assert.equal('y0', JSON.parse(res.payload).x0)
-      assert.equal('c1', JSON.parse(res.payload).t)
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal('3333', JSON.parse(res.payload).m)
+      Assert.equal('y0', JSON.parse(res.payload).x0)
+      Assert.equal('c1', JSON.parse(res.payload).t)
 
       done()
     })
   })
 
-  test('simple test post 2', function(done) {
+  test('simple test post 2', function (done) {
     var url = '/t0/c0/44'
 
     server.inject({
       url: url,
       method: 'POST'
-    }, function(res){
-      assert.equal(200, res.statusCode)
-      assert.equal('44', JSON.parse(res.payload).m)
-      assert.equal('y0', JSON.parse(res.payload).x0)
-      assert.equal('c2', JSON.parse(res.payload).t)
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal('44', JSON.parse(res.payload).m)
+      Assert.equal('y0', JSON.parse(res.payload).x0)
+      Assert.equal('c2', JSON.parse(res.payload).t)
 
       done()
     })
   })
 
-  test('simple test post with payload', function(done) {
+  test('simple test post with payload', function (done) {
     var url = '/t0/c0/44'
 
     server.inject({
       url: url,
       method: 'POST',
       payload: {p: 'l'}
-    }, function(res){
-      assert.equal(200, res.statusCode)
-      assert.equal('44', JSON.parse(res.payload).m)
-      assert.equal('y0', JSON.parse(res.payload).x0)
-      assert.equal('c2', JSON.parse(res.payload).t)
-      assert.equal('l', JSON.parse(res.payload).p)
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal('44', JSON.parse(res.payload).m)
+      Assert.equal('y0', JSON.parse(res.payload).x0)
+      Assert.equal('c2', JSON.parse(res.payload).t)
+      Assert.equal('l', JSON.parse(res.payload).p)
 
       done()
     })
   })
 
-  test('simple test post with payload', function(done) {
+  test('simple test post with payload', function (done) {
     var url = '/not/valid/endpoint'
 
     server.inject({
       url: url,
       method: 'POST',
       payload: {p: 'l'}
-    }, function(res){
-      assert.equal(404, res.statusCode)
+    }, function (res) {
+      Assert.equal(404, res.statusCode)
 
       done()
     })
   })
 
-  test('simple test get with act error', function(done) {
+  test('simple test get with act error', function (done) {
     var url = '/t0/e1'
 
     server.inject({
       url: url,
       method: 'GET'
-    }, function(res){
-      assert.equal(500, res.statusCode)
+    }, function (res) {
+      Assert.equal(500, res.statusCode)
 
       done()
     })
   })
 
-  test('simple test 1 without startware', function(done) {
+  test('simple test 1 without startware', function (done) {
     var url = '/r0/x0'
 
-    server.inject(url, function(res){
-      assert.equal(200, res.statusCode)
-      assert.equal('c0', JSON.parse(res.payload).t)
-      assert.notEqual('y0', JSON.parse(res.payload).x0)
+    server.inject(url, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal('c0', JSON.parse(res.payload).t)
+      Assert.notEqual('y0', JSON.parse(res.payload).x0)
 
       done()
     })
   })
 
-  test('simple parameter test, data: false', function(done) {
+  test('simple parameter test, data: false', function (done) {
     var url = '/t0/x1?x=b'
 
     server.inject({
       url: url,
       method: 'POST'
-    }, function(res){
-      assert.equal(200, res.statusCode)
-      assert.deepEqual( {x:'b'}, JSON.parse(res.payload))
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.deepEqual({x: 'b'}, JSON.parse(res.payload))
 
       done()
     })
   })
 
-  test('simple request body test, data: false', function(done) {
+  test('simple request body test, data: false', function (done) {
     var url = '/t0/x1'
 
     server.inject({
       url: url,
       method: 'POST',
       payload: {x: 'b'}
-    }, function(res){
-      assert.equal(200, res.statusCode)
-      assert.deepEqual( {x:'b'}, JSON.parse(res.payload))
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.deepEqual({x: 'b'}, JSON.parse(res.payload))
 
       done()
     })
   })
 
-  test('simple parameter test, data: false', function(done) {
+  test('simple parameter test, data: false', function (done) {
     var url = '/t0/x2?x=b'
 
     server.inject({
       url: url,
       method: 'POST'
-    }, function(res){
-      assert.equal(200, res.statusCode)
-      assert.deepEqual( {x:'b', loc: 0}, JSON.parse(res.payload))
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.deepEqual({x: 'b', loc: 0}, JSON.parse(res.payload))
 
       done()
     })
   })
 
-  test('simple request body test, data: false', function(done) {
+  test('simple request body test, data: false', function (done) {
     var url = '/t0/x2'
 
     server.inject({
       url: url,
       method: 'POST',
       payload: {x: 'b'}
-    }, function(res){
-      assert.equal(200, res.statusCode)
-      assert.deepEqual( {x:'b', loc: 1}, JSON.parse(res.payload))
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.deepEqual({x: 'b', loc: 1}, JSON.parse(res.payload))
 
       done()
     })

--- a/test/hapi.url.test.js
+++ b/test/hapi.url.test.js
@@ -145,4 +145,62 @@ suite('test server suite', function() {
       done()
     })
   })
+
+  test('simple parameter test, data: false', function(done) {
+    var url = '/t0/x1?x=b'
+
+    server.inject({
+      url: url,
+      method: 'POST'
+    }, function(res){
+      assert.equal(200, res.statusCode)
+      assert.deepEqual( {x:'b'}, JSON.parse(res.payload))
+
+      done()
+    })
+  })
+
+  test('simple request body test, data: false', function(done) {
+    var url = '/t0/x1'
+
+    server.inject({
+      url: url,
+      method: 'POST',
+      payload: {x: 'b'}
+    }, function(res){
+      assert.equal(200, res.statusCode)
+      assert.deepEqual( {x:'b'}, JSON.parse(res.payload))
+
+      done()
+    })
+  })
+
+  test('simple parameter test, data: false', function(done) {
+    var url = '/t0/x2?x=b'
+
+    server.inject({
+      url: url,
+      method: 'POST'
+    }, function(res){
+      assert.equal(200, res.statusCode)
+      assert.deepEqual( {x:'b', loc: 0}, JSON.parse(res.payload))
+
+      done()
+    })
+  })
+
+  test('simple request body test, data: false', function(done) {
+    var url = '/t0/x2'
+
+    server.inject({
+      url: url,
+      method: 'POST',
+      payload: {x: 'b'}
+    }, function(res){
+      assert.equal(200, res.statusCode)
+      assert.deepEqual( {x:'b', loc: 1}, JSON.parse(res.payload))
+
+      done()
+    })
+  })
 })

--- a/test/startware-fail.js
+++ b/test/startware-fail.js
@@ -1,41 +1,40 @@
-"use strict";
+'use strict'
 
-var assert = require('assert')
+var Assert = require('assert')
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
-var suite = lab.suite;
-var test = lab.test;
-var before = lab.before;
+var suite = lab.suite
+var test = lab.test
+var before = lab.before
 
 var agent
-var seneca
 
-var util = require('./util.js')
+var Util = require('./util.js')
 
 var redirectLocation = '/home'
-function failed_startware(req, res, done){
+function failed_startware (req, res, done) {
   done({http$: {redirect: redirectLocation, status: '301'}})
 }
 
-suite('startware-fail tests ', function() {
-  before({}, function(done){
-    util.init(function(err, agentData, si){
+suite('startware-fail tests ', function () {
+  before({}, function (done) {
+    Util.init(function (err, agentData, si) {
+      Assert(!err)
+
       agent = agentData
-      seneca = si
 
-
-      si.add({role: 'test', cmd:'service'}, function(args, cb){
+      si.add({role: 'test', cmd: 'service'}, function (args, cb) {
         return cb(null, {ok: true, test: true})
       })
       si.act({
-        role:'web',
-        plugin:'test',
-        use:{
-          prefix:'/api',
+        role: 'web',
+        plugin: 'test',
+        use: {
+          prefix: '/api',
           startware: failed_startware,
-          pin:{role:'test',cmd:'*'},
+          pin: {role: 'test', cmd: '*'},
           map: {
-            service: { GET: true }
+            service: {GET: true}
           }
         }
       })
@@ -43,13 +42,14 @@ suite('startware-fail tests ', function() {
     })
   })
 
-  test('simple test', function(done) {
+  test('simple test', function (done) {
     agent
       .get('/api/service')
       .expect(301)
-      .end(function (err, res){
-        util.log(res)
-        assert.equal(redirectLocation, res.header.location)
+      .end(function (err, res) {
+        Assert(!err)
+        Util.log(res)
+        Assert.equal(redirectLocation, res.header.location)
         console.log('PASS STARTWARE FAIL TEST')
         done()
       })

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -1,309 +1,317 @@
-"use strict";
+'use strict'
 
-var assert = require('assert')
+var Assert = require('assert')
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
-var suite = lab.suite;
-var test = lab.test;
-var before = lab.before;
+var suite = lab.suite
+var test = lab.test
+var before = lab.before
 
-var agent
-var seneca
+var Util = require('./util.js')
 
-var util = require('./util.js')
+suite('test server suite', function () {
+  var agent
 
-suite('test server suite', function() {
-  before({}, function(done){
-    require('./configure-server.js').init(function(err, agentData, si){
+  before({}, function (done) {
+    require('./configure-server.js').init(function (err, agentData, si) {
+      Assert.ok(!err)
       agent = agentData
-      seneca = si
+
       done()
     })
   })
 
-  test('simple test 1', function(done) {
+  test('simple test 1', function (done) {
     var url = '/t0/a0/b0?a1=b1&a2=b2'
 
     agent
       .get(url)
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.equal( res.headers.h0, 'i0' )
-        assert.deepEqual(res.body,{ r0: 'r0b0', r1: 'r1b1', r2: 'r2b2', x0: 'ry0' })
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.equal(res.headers.h0, 'i0')
+        Assert.deepEqual(res.body, {r0: 'r0b0', r1: 'r1b1', r2: 'r2b2', x0: 'ry0'})
         done()
       })
   })
 
-  test('simple test 1', function(done) {
+  test('simple test 1', function (done) {
     var url = '/t0/a0/b0?a1=b1'
 
     agent
       .post(url)
-      .send({a2:'b2',c:'c'})
+      .send({a2: 'b2', c: 'c'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.equal( res.headers.h0, 'i0' )
-        assert.deepEqual(res.body,{ r0: 'r0pb0', r1: 'pr1b1', r2: 'r2b2', x0: 'ry0', c: 'C' })
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.equal(res.headers.h0, 'i0')
+        Assert.deepEqual(res.body, {r0: 'r0pb0', r1: 'pr1b1', r2: 'r2b2', x0: 'ry0', c: 'C'})
         done()
       })
   })
 
-  test('simple test 3', function(done) {
+  test('simple test 3', function (done) {
     var url = '/t0/a0/b0?a1=b1'
 
     agent
       .put(url)
-      .send({a2:'b2'})
+      .send({a2: 'b2'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual(JSON.parse(res.text),{"r0":"r0undefined","r1":"r1pundefined","r2":"r2b2","x0":"ry0","http$":{"headers":{"h0":"i0"}},"o0":"p0","q0":"u0"})
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(JSON.parse(res.text), {
+          'r0': 'r0undefined',
+          'r1': 'r1pundefined',
+          'r2': 'r2b2',
+          'x0': 'ry0',
+          'http$': {'headers': {'h0': 'i0'}},
+          'o0': 'p0',
+          'q0': 'u0'
+        })
         done()
       })
   })
 
-  test('simple test 4', function(done) {
+  test('simple test 4', function (done) {
     var url = '/t0/c1?d0=e0'
 
     agent
       .get(url)
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual(res.body,{ d0: 'e0f0' })
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {d0: 'e0f0'})
         done()
       })
   })
 
-  test('simple test 5', function(done) {
+  test('simple test 5', function (done) {
     var url = '/t0/c2'
 
     agent
       .post(url)
-      .send({d1:'e1',d2:'e2'})
+      .send({d1: 'e1', d2: 'e2'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual(res.body,{ d1: 'e1f1', d2: 'e2' })
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {d1: 'e1f1', d2: 'e2'})
         done()
       })
   })
 
-  test('simple test 6', function(done) {
+  test('simple test 6', function (done) {
     var url = '/t0/c2'
 
     agent
       .put(url)
-      .send({d1:'e1',d2:'e2'})
+      .send({d1: 'e1', d2: 'e2'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual(res.body,{ d1: 'e1f1', d2: 'e2' })
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {d1: 'e1f1', d2: 'e2'})
         done()
       })
   })
 
-  test('simple test 7', function(done) {
+  test('simple test 7', function (done) {
     var url = '/t0/e0'
 
     agent
       .get(url)
-      .send({d1:'e1',d2:'e2'})
+      .send({d1: 'e1', d2: 'e2'})
       .expect(500)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual(res.body,{ error: 'Error: seneca: Action cmd:e0,role:api failed: e0.' })
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {error: 'Error: seneca: Action cmd:e0,role:api failed: e0.'})
         done()
       })
   })
 
-  test('simple test 8', function(done) {
+  test('simple test 8', function (done) {
     var url = '/t0/e1'
 
     agent
       .get(url)
-      .send({d1:'e1',d2:'e2'})
+      .send({d1: 'e1', d2: 'e2'})
       .expect(500)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.equal( res.text, 'e1' )
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.equal(res.text, 'e1')
         done()
       })
   })
 
-  test('simple test 9', function(done) {
+  test('simple test 9', function (done) {
     var url = '/t0/r0'
 
     agent
       .get(url)
       .expect(400)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual(res.body, { ok: false, why: 'No input will satisfy me.' })
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {ok: false, why: 'No input will satisfy me.'})
         done()
       })
   })
 
   // non-interference with preceding middleware
-  test('simple test 10', function(done) {
+  test('simple test 10', function (done) {
     var url = '/a'
 
     agent
       .get(url)
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.equal( res.text, 'A' )
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.equal(res.text, 'A')
         done()
       })
   })
 
   // startware not triggered
-  test('simple test 11', function(done) {
+  test('simple test 11', function (done) {
     var url = '/a'
 
     agent
       .post(url)
       .send({a: 'a'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual(res.body, {a:'a'})
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {a: 'a'})
         done()
       })
   })
 
   // premap not triggered
-  test('simple test 12', function(done) {
+  test('simple test 12', function (done) {
     var url = '/a'
 
     agent
       .post(url)
-      .send({a:'a',c:'c'})
+      .send({a: 'a', c: 'c'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual(res.body, {a:'a',c:'c'})
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {a: 'a', c: 'c'})
         done()
       })
   })
 
   // non-interference with following middleware
-  test('simple test 13', function(done) {
+  test('simple test 13', function (done) {
     var url = '/b'
 
     agent
       .get(url)
-      .send({a:'a',c:'c'})
+      .send({a: 'a', c: 'c'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.equal(res.text, 'B')
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.equal(res.text, 'B')
         done()
       })
   })
 
   // startware triggered as following!
-  test('simple test 13', function(done) {
+  test('simple test 13', function (done) {
     var url = '/b'
 
     agent
       .post(url)
-      .send({b:'b'})
+      .send({b: 'b'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual( res.body, {b:'B'} )
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {b: 'B'})
         done()
       })
   })
 
   // premap not triggered as no map
-  test('simple test 13', function(done) {
+  test('simple test 13', function (done) {
     var url = '/b'
 
     agent
       .post(url)
-      .send({b:'b',c:'c'})
+      .send({b: 'b', c: 'c'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual( res.body, {b:'B',c:'c'} )
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {b: 'B', c: 'c'})
         done()
       })
   })
 
-  test('simple request body test, data: false', function(done) {
+  test('simple request body test, data: false', function (done) {
     var url = '/t0/x1'
 
     agent
       .post(url)
       .send({x: 'b'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual( res.body, {x:'b'} )
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {x: 'b'})
         done()
       })
   })
 
-  test('simple parameter test, data: false', function(done) {
+  test('simple parameter test, data: false', function (done) {
     var url = '/t0/x1?x=b'
 
     agent
       .post(url)
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual( res.body, {x:'b'} )
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {x: 'b'})
         done()
       })
   })
 
-  test('simple request body test, data: true', function(done) {
+  test('simple request body test, data: true', function (done) {
     var url = '/t0/x2'
 
     agent
       .post(url)
       .send({x: 'b'})
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual( res.body, {x:'b', loc: 1} )
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {x: 'b', loc: 1})
         done()
       })
   })
 
-  test('simple parameter test, data: true', function(done) {
+  test('simple parameter test, data: true', function (done) {
     var url = '/t0/x2?x=b'
 
     agent
       .post(url)
       .expect(200)
-      .end(function (err, res){
-        util.log(res)
-        assert.ok( !err )
-        assert.deepEqual( res.body, {x:'b', loc: 0} )
+      .end(function (err, res) {
+        Util.log(res)
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {x: 'b', loc: 0})
         done()
       })
   })

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -249,4 +249,62 @@ suite('test server suite', function() {
         done()
       })
   })
+
+  test('simple request body test, data: false', function(done) {
+    var url = '/t0/x1'
+
+    agent
+      .post(url)
+      .send({x: 'b'})
+      .expect(200)
+      .end(function (err, res){
+        util.log(res)
+        assert.ok( !err )
+        assert.deepEqual( res.body, {x:'b'} )
+        done()
+      })
+  })
+
+  test('simple parameter test, data: false', function(done) {
+    var url = '/t0/x1?x=b'
+
+    agent
+      .post(url)
+      .expect(200)
+      .end(function (err, res){
+        util.log(res)
+        assert.ok( !err )
+        assert.deepEqual( res.body, {x:'b'} )
+        done()
+      })
+  })
+
+  test('simple request body test, data: true', function(done) {
+    var url = '/t0/x2'
+
+    agent
+      .post(url)
+      .send({x: 'b'})
+      .expect(200)
+      .end(function (err, res){
+        util.log(res)
+        assert.ok( !err )
+        assert.deepEqual( res.body, {x:'b', loc: 1} )
+        done()
+      })
+  })
+
+  test('simple parameter test, data: true', function(done) {
+    var url = '/t0/x2?x=b'
+
+    agent
+      .post(url)
+      .expect(200)
+      .end(function (err, res){
+        util.log(res)
+        assert.ok( !err )
+        assert.deepEqual( res.body, {x:'b', loc: 0} )
+        done()
+      })
+  })
 })

--- a/test/util.js
+++ b/test/util.js
@@ -1,35 +1,31 @@
-var assert = require('assert')
-
-exports.init = function(cb){
+exports.init = function (cb) {
   var agent
   var request = require('supertest')
   var express = require('express')
   var cookieparser = require('cookie-parser')
-  var bodyparser   = require('body-parser')
-  var seneca = require('seneca')
+  var bodyparser = require('body-parser')
 
   var si = require('seneca')({
-    default_plugins: { web: false },
+    default_plugins: {web: false},
     log: 'silent'
   })
   si.use('../web.js')
 
-  si.ready(function(err){
-    if( err ) return process.exit( !console.error(err) );
+  si.ready(function (err) {
+    if (err) return process.exit(!console.error(err))
 
     var web = si.export('web')
     var app = express()
-    app.use( cookieparser() )
-    app.use( bodyparser.json() )
-    app.use( web )
+    app.use(cookieparser())
+    app.use(bodyparser.json())
+    app.use(web)
     agent = request(app)
     cb(null, agent, si)
   })
 }
 
-exports.log = function (res){
+exports.log = function (res) {
   // comment next line for logging of req/responses
-  return
   console.log('\n****************************************')
   console.log('REQUEST URL : ', JSON.stringify(res.req.path))
   console.log('REQUEST     : ', JSON.stringify(res))

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -1,83 +1,84 @@
 /* Copyright (c) 2010-2015 Richard Rodger */
-"use strict";
+'use strict'
 
-var _       = require('lodash')
-var assert  = require('assert')
-var seneca  = require('seneca')
-var success = require('success')
+var _ = require('lodash')
+var Assert = require('assert')
+var Seneca = require('seneca')
+var Success = require('success')
 
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
-var suite = lab.suite;
-var test = lab.test;
-var before = lab.before;
+var suite = lab.suite
+var test = lab.test
+var before = lab.before
 
 var si
 
-suite('configuration suite', function() {
-  before({}, function(done){
-
-    si = seneca({log:'silent'})
+suite('configuration suite', function () {
+  before({}, function (done) {
+    si = Seneca({log: 'silent'})
     si.use('../web.js')
     done()
   })
 
-  test('empty', function(done) {
-    si.act({role:'web',use:{pin:{},map:{}}}, done)
+  test('empty', function (done) {
+    si.act({role: 'web', use: {pin: {}, map: {}}}, done)
   })
 
 
-  test('bad', function(done) {
-    var lsi = seneca( {log:'silent',debug:{undead:true} , errhandler:function(err){
-      assert.equal('seneca: Action role:web failed: web-use: The property \'pin\' is missing and is always required (parent: spec)..',err.message)
-      done()
-    }})
+  test('bad', function (done) {
+    var lsi = Seneca({
+      log: 'silent', debug: {undead: true}, errhandler: function (err) {
+        Assert.equal('seneca: Action role:web failed: web-use: The property \'pin\' is missing and is always required (parent: spec)..', err.message)
+        done()
+      }
+    })
     lsi.use('../web.js')
-    lsi.use( function bad(){
-      this.act({role:'web',use:{}})
+    lsi.use(function bad () {
+      this.act({role: 'web', use: {}})
     })
   })
 
 
-  test('config', function(done) {
+  test('config', function (done) {
     si.act(
       {
-        role:'web',
-        use:{
-          pin:{},
-          map:{}
+        role: 'web',
+        use: {
+          pin: {},
+          map: {}
         },
-        config:{a:1},
-        plugin:'aaa'
+        config: {a: 1},
+        plugin: 'aaa'
       },
-      function(err,out){
-        assert.ok( null == err)
+      function (err, out) {
+        Assert.ok(null == err)
 
-        si.act({role:'web',get:'config', plugin:'aaa'}, function(err,out){
-          assert.ok( null == err)
-          assert.equal( out.a, 1 )
+        si.act({role: 'web', get: 'config', plugin: 'aaa'}, function (err, out) {
+          Assert.ok(null == err)
+          Assert.equal(out.a, 1)
           done()
         })
       }
     )
   })
 
-  test('source', function(done) {
+  test('source', function (done) {
     si.act(
       {
-        role:'web',
-        set:'source',
-        title:'t1',
-        source:'s1'
+        role: 'web',
+        set: 'source',
+        title: 't1',
+        source: 's1'
       },
-      function(err,out){
-        assert.ok( null == err)
+      function (err, out) {
+        Assert.ok(null == err)
 
-        si.act({role:'web',get:'sourcelist'}, function(err,out){
+        si.act({role: 'web', get: 'sourcelist'}, function (err, out) {
           //console.log(out)
-          assert.ok( null == err)
-          assert.equal( out.length, 1 )
-          assert.equal( '\n;// t1\ns1', out[0] )
+          Assert.ok(null == err)
+          Assert.equal(out.length, 1)
+          Assert.equal('\n;// t1\ns1', out[0])
           done()
         })
       }
@@ -85,47 +86,52 @@ suite('configuration suite', function() {
   })
 
 
-  test('plugin', function(done) {
-    var si = seneca({log:'silent',errhandler:done})
+  test('plugin', function (done) {
+    var si = Seneca({log: 'silent', errhandler: done})
     si.use('../web.js')
 
-    si.use(function qaz(){
-      this.add('role:foo,cmd:zig',function(args,done){
-        done(null,{bar:args.zoo+'g'})
+    si.use(function qaz () {
+      this.add('role:foo,cmd:zig', function (args, done) {
+        done(null, {bar: args.zoo + 'g'})
       })
-      this.add('role:foo,cmd:bar',function(args,done){
-        done(null,{bar:args.zoo+'b'})
+      this.add('role:foo,cmd:bar', function (args, done) {
+        done(null, {bar: args.zoo + 'b'})
       })
-      this.add('role:foo,cmd:qaz',function(args,done){
-        done(null,{qaz:args.zoo+'z'})
+      this.add('role:foo,cmd:qaz', function (args, done) {
+        done(null, {qaz: args.zoo + 'z'})
       })
 
-      this.act('role:web',{use:function(req,res,next){next();}})
-
-      this.act('role:web',{use:{
-        prefix:'/foo',
-        pin:{role:'foo',cmd:'*'},
-        map:{
-          zig: true,
-          bar: {GET:true},
-          qaz: {GET:true,POST:true}
+      this.act('role:web', {
+        use: function (req, res, next) {
+          next()
         }
-      }})
+      })
+
+      this.act('role:web', {
+        use: {
+          prefix: '/foo',
+          pin: {role: 'foo', cmd: '*'},
+          map: {
+            zig: true,
+            bar: {GET: true},
+            qaz: {GET: true, POST: true}
+          }
+        }
+      })
     })
 
-    si.act('role:web,list:service', success(done, function(out){
-      assert.equal(out.length,4)
+    si.act('role:web,list:service', Success(done, function (out) {
+      Assert.equal(out.length, 4)
 
-      si.act('role:web,list:route',success(done,function(out){
-        assert.equal(out.length,4)
+      si.act('role:web,list:route', Success(done, function (out) {
+        Assert.equal(out.length, 4)
 
-        si.act({role:'web',stats:true},success(done,function(out){
-          assert.equal(4,_.keys(out).length)
+        si.act({role: 'web', stats: true}, Success(done, function (out) {
+          Assert.equal(4, _.keys(out).length)
           done()
         }))
       }))
     }))
   })
-
 })
 

--- a/web.js
+++ b/web.js
@@ -385,11 +385,24 @@ module.exports = function (options) {
             request.seneca.act('role: web, do: startware', {req: request}, function (err, out) {
               if (err) return reply(err)
 
-              if (data) {
-                pattern.data = request.payload
-              }
               if (out) {
                 pattern = _.extend({}, pattern, out)
+              }
+
+              if (request.payload) {
+                if (data) {
+                  pattern.data = request.payload
+                }
+                else {
+                  pattern = _.extend({}, request.payload, pattern)
+                }
+              }
+
+              if (request.params) {
+                pattern = _.extend({}, request.params, pattern)
+              }
+              if (request.query) {
+                pattern = _.extend({}, request.query, pattern)
               }
 
               request.seneca.act( pattern, function (err, result) {

--- a/web.js
+++ b/web.js
@@ -384,31 +384,29 @@ module.exports = function (options) {
             do_maprouter()
           }
 
-          function do_maprouter (out) {
+          function do_maprouter () {
             request.seneca.act('role: web, do: startware', {req: request}, function (err, out) {
               if (err) return reply(err)
 
-              if (out) {
-                pattern = _.extend({}, pattern, out)
-              }
+              var currentPattern = _.clone(pattern)
 
               if (request.payload) {
                 if (data) {
-                  pattern.data = request.payload
+                  currentPattern.data = request.payload
                 }
                 else {
-                  pattern = _.extend({}, request.payload, pattern)
+                  currentPattern = _.extend({}, request.payload, currentPattern)
                 }
               }
 
               if (request.params) {
-                pattern = _.extend({}, request.params, pattern)
+                currentPattern = _.extend({}, request.params, currentPattern)
               }
               if (request.query) {
-                pattern = _.extend({}, request.query, pattern)
+                currentPattern = _.extend({}, request.query, currentPattern)
               }
 
-              request.seneca.act( pattern, function (err, result) {
+              request.seneca.act( currentPattern, function (err, result) {
                 if (err) {
                   return sendreply(err)
                 }

--- a/web.js
+++ b/web.js
@@ -460,7 +460,7 @@ module.exports = function (options) {
       var tokens = path.split('/')
 
       for (var i in tokens) {
-        if (tokens[i].indexOf(':') === 0) {
+        if (tokens[i].charAt(0) === ':') {
           tokens[i] = '{' + tokens[i].substr(1) + '}'
         }
       }

--- a/web.js
+++ b/web.js
@@ -362,6 +362,9 @@ module.exports = function (options) {
 
     var pattern = routespecs.pattern
     var path = routespecs.fullurl
+
+    path = changeToHapi(path)
+
     var data = routespecs.data || false
 
     var hapi_route = {
@@ -453,6 +456,17 @@ module.exports = function (options) {
         internals.server.route( hapi_route )
         done()
       })
+    }
+
+    function changeToHapi (path) {
+      var tokens = path.split('/')
+
+      for (var i in tokens) {
+        if (tokens[i].indexOf(':') === 0) {
+          tokens[i] = '{' + tokens[i].substr(1) + '}'
+        }
+      }
+      return tokens.join('/')
     }
   }
 


### PR DESCRIPTION
- Seneca web path parameters should use same syntax for Hapi/Express paths #42
- Add query, body payload or path parameters to seneca action arguments in similar way as for Express #43