### PR TITLE
Remove this as the first argument. Fixes #66

### DIFF
--- a/test/configure-server.js
+++ b/test/configure-server.js
@@ -68,6 +68,13 @@ exports.init = function (done) {
         response(new Error('e1'))
       })
 
+      this.add('role:api,cmd:n0', function (args, response) {
+        response(null, {
+          name: args.name,
+          id: args.id
+        })
+      })
+
       this.add('role:api,cmd:r0', function (args, response) {
         response(null, {
           ok: false,
@@ -165,6 +172,10 @@ exports.init = function (done) {
                 }
                 else res.send(obj)
               }
+            },
+
+            n0: {
+              alias: '/n0/:name/:id'
             },
 
             r0: true

--- a/test/hapi.configure.server.js
+++ b/test/hapi.configure.server.js
@@ -68,6 +68,13 @@ exports.init = function (done) {
       cb(new Error('some error'))
     }
 
+    function n0 (msg, cb) {
+      cb(null, {
+        name: msg.name,
+        id: msg.id
+      })
+    }
+
     function x1 (args, cb) {
       cb(null, {x: args.x})
     }
@@ -86,6 +93,7 @@ exports.init = function (done) {
       .add('role:api,cmd:e1', e1)
       .add('role:api,cmd:x1', x1)
       .add('role:api,cmd:x2', x2)
+      .add('role:api,cmd:n0', n0)
 
     seneca.ready(function () {
       seneca.act('role:web', {
@@ -102,6 +110,7 @@ exports.init = function (done) {
             c1: {GET: true, POST: true, alias: '/a0/:m'},
             c2: {POST: true, alias: '/c0/:m'},
             e1: {GET: true, alias: '/e1'},
+            n0: {GET: true, alias: '/n0/:name/:id'},
             x1: {POST: true},
             x2: {POST: true, data: true}
           }

--- a/test/hapi.url.test.js
+++ b/test/hapi.url.test.js
@@ -209,4 +209,18 @@ suite('test server suite', function () {
       done()
     })
   })
+
+  test('named parameter name and id', function (done) {
+    var url = '/t0/n0/name1/id1'
+
+    server.inject({
+      url: url,
+      method: 'GET'
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.deepEqual({name: 'name1', id: 'id1'}, JSON.parse(res.payload))
+
+      done()
+    })
+  })
 })

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -297,4 +297,17 @@ suite('test server suite', function () {
         done()
       })
   })
+
+  test('named parameter name and id', function (done) {
+    var url = '/t0/n0/name1/id1'
+
+    agent
+      .get(url)
+      .expect(200)
+      .end(function (err, res) {
+        Assert.ok(!err)
+        Assert.deepEqual(res.body, {name: 'name1', id: 'id1'})
+        done()
+      })
+  })
 })

--- a/web.js
+++ b/web.js
@@ -853,7 +853,7 @@ function resolve_actions (instance, routespecs) {
     if (!actmeta) return
 
     var act = function (args, cb) {
-      this.act(this, _.extend({}, routespec.pattern, args), cb)
+      this.act(_.extend({}, routespec.pattern, args), cb)
     }
 
     routespec.act = act


### PR DESCRIPTION
The change of the this.act() call in commit https://github.com/senecajs/seneca-web/commit/5d7d074753b6e99feac076eb91c785c95b13d01d at line number 577 passes the seneca object as the first argument to the function. Therefore the properties and the base properties of the seneca object were _.extend'ed to the pattern matching object (api_act(), Common.parsePattern()), thus overriding values for properties like id, name etc.