### PR TITLE
Provide option to disable body parser when using express/connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ map: {
 Hapi routes do not use the `secure` option. All routes are secured using `auth`. Both
 pass and fail redirects are supported.
 
+## Body Parser
+
+If a body parser has not been provided using express or connect, seneca-web will attempt
+to parse the body. This will not work if a body-parser has already been defined for the app.
+To disable this behavior, pass `{options: {parseBody: false}}` to the plugin options.
+
 ## Examples
 A number of examples showing basic and secure usage for hapi and express as well as
 showing connect and log usage are provided in [./docs/examples](). Examples include,

--- a/lib/adapters/connect.js
+++ b/lib/adapters/connect.js
@@ -17,31 +17,35 @@ module.exports = function connect (options, context, auth, routes, done) {
     context.use(route.path, (request, reply, next) => {
       // Connect does not work with http verbs
       if (route.methods.indexOf(request.method) !== -1) {
-        ReadBody(request, (err, body) => {
+        // if parsing body, call into ReadBody otherwise just finish.
+        if (options.parseBody) { return ReadBody(request, finish) }
+        finish(null, request.body || {})
+      }
+
+      function finish (err, body) {
+        if (err) {
+          reply.writeHead(500, {'Content-Type': 'application/json'})
+          return reply.end(JSON.stringify(err))
+        }
+
+        var payload = {
+          request$: request,
+          response$: reply,
+          args: {
+            body: body,
+            route: route,
+            query: QueryString.parse(URL.parse(request.originalUrl).query)
+          }
+        }
+        seneca.act(route.pattern, payload, (err, response) => {
           if (err) {
             reply.writeHead(500, {'Content-Type': 'application/json'})
             return reply.end(JSON.stringify(err))
           }
-
-          var payload = {
-            request$: request,
-            response$: reply,
-            args: {
-              body: body,
-              route: route,
-              query: QueryString.parse(URL.parse(request.originalUrl).query)
-            }
+          if (route.autoreply) {
+            reply.writeHead(200, {'Content-Type': 'application/json'})
+            reply.end(JSON.stringify(response))
           }
-          seneca.act(route.pattern, payload, (err, response) => {
-            if (err) {
-              reply.writeHead(500, {'Content-Type': 'application/json'})
-              return reply.end(JSON.stringify(err))
-            }
-            if (route.autoreply) {
-              reply.writeHead(200, {'Content-Type': 'application/json'})
-              reply.end(JSON.stringify(response))
-            }
-          })
         })
       }
     })

--- a/lib/adapters/express.js
+++ b/lib/adapters/express.js
@@ -25,13 +25,13 @@ module.exports = function express (options, context, auth, routes, done) {
       // on if the route is for authorization, is
       // secure, or neither. Each is explained below.
       if (!route.auth && !route.secure) {
-        unsecuredRoute(seneca, context, method, route)
+        unsecuredRoute(seneca, options, context, method, route)
       }
       else if (route.secure) {
-        securedRoute(seneca, context, method, route)
+        securedRoute(seneca, options, context, method, route)
       }
       else if (route.auth) {
-        authRoute(seneca, context, method, route, auth)
+        authRoute(seneca, options, context, method, route, auth)
       }
     })
   })
@@ -41,11 +41,14 @@ module.exports = function express (options, context, auth, routes, done) {
 
 // All routes ultimately get handled by this handler
 // if they have not already be redirected or responded.
-function handleRoute (seneca, request, reply, route) {
+function handleRoute (seneca, options, request, reply, route) {
+  if (options.parseBody) { return ReadBody(request, finish) }
+  finish(null, request.body || {})
+
   // Express requires a body parser to work in production
   // This util creates a body obj without neededing a parser
   // but doesn't impact loading one in.
-  ReadBody(request, (err, body) => {
+  function finish (err, body) {
     if (err) {
       return reply.status(500).send(err)
     }
@@ -79,20 +82,20 @@ function handleRoute (seneca, request, reply, route) {
         return reply.send(response)
       }
     })
-  })
+  }
 }
 
 // Unsecured routes just call the handler directly, no magic.
-function unsecuredRoute (seneca, context, method, route) {
+function unsecuredRoute (seneca, options, context, method, route) {
   context[method](route.path, (request, reply) => {
-    handleRoute(seneca, request, reply, route)
+    handleRoute(seneca, options, request, reply, route)
   })
 }
 
 // Auth routes call passport.authenticate and can and do redirect
 // depending on pass or failure. Generally this means you don't
 // need a seneca handler set as the redirects happend instead.
-function authRoute (seneca, context, method, route, auth) {
+function authRoute (seneca, options, context, method, route, auth) {
   var opts = {
     failureRedirect: route.auth.fail,
     successRedirect: route.auth.pass
@@ -100,19 +103,19 @@ function authRoute (seneca, context, method, route, auth) {
 
   var strategy = auth.authenticate(route.auth.strategy, opts)
   context[method](route.path, strategy, (request, reply) => {
-    handleRoute(seneca, request, reply, route)
+    handleRoute(seneca, options, request, reply, route)
   })
 }
 
 // Secured routes check if a valid req.user exists as per express
 // general practices. Req.logout() clears this. The handler will
 // redirect to a fail redirect in the case of unauthenticated calls.
-function securedRoute (seneca, context, method, route) {
+function securedRoute (seneca, options, context, method, route) {
   context[method](route.path, (request, reply) => {
     if (!request.user) {
       return reply.redirect(route.secure.fail)
     }
 
-    handleRoute(seneca, request, reply, route)
+    handleRoute(seneca, options, request, reply, route)
   })
 }

--- a/web.js
+++ b/web.js
@@ -12,7 +12,9 @@ var opts = {
   context: null,
   adapter: 'log',
   auth: null,
-  options: {},
+  options: {
+    parseBody: true
+  },
   adapters: {
     hapi: HapiAdapter,
     express: ExpressAdapter,


### PR DESCRIPTION
Fixes #92 

The diffs look a little messy for the connect one.  The linter was complaining about having a function inside an if statement, so all the indentation had to change a little bit.  Also, the express one wasn't passing around options so I had to add `options` to all the functions :(